### PR TITLE
Refactor fragments

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = true

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = W391,D105,W504
+ignore = W391,D105,W503,W504
 max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+bin/
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ target/
 
 # Type Checking
 .mypy_cache
+
+# Misc
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: python
 python:
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 install:
-  - pip install coveralls mypy==0.650 flake8==3.6.0 flake8-docstrings==1.3.1 pyyaml
+  - pip install coveralls mypy==0.750 flake8==3.7.9 flake8-docstrings==1.5.0
 script:
   - flake8
   - mypy climatecontrol
-  - pip install "pytest>=3.8.1,<4.0" && python setup.py test
+  - pip install "pytest" && python setup.py test
 after_success:
   - coveralls
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow "_from_env" postfix in variables and load settings from the specified
+  environment variable (similar to "from_file").
+- Add "update_log" property which specifies a log of all variables loaded or
+  removed/replaced.
+- Allow overwriting / merging lists
+
+### Changed
+
+- Use fragments as base data structure for building settings map
+- Add python 3.7 and 3.8 to CI and update development environment config to 3.8
+
+
 ## [0.7.3] - 2019-01-17
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |Coverage Status| |PyPi Status| |PyPI license|
+|Build Status| |Coverage Status| |PyPi Status| |PyPI license| |PyPI pyversions|
 
 
 .. image:: https://raw.githubusercontent.com/daviskirk/climatecontrol/logo/climatecontrol-text.svg?sanitize=true
@@ -88,37 +88,6 @@ settings. For this situation we can delimit sections using a double underscore:
    }
 
 
-Finally if you decide that your settings are simpler and you know that your
-section names do not have underscores, you can use the ``implicit_depth``
-option, which allows you to add a new section at every single underscore (up to
-the depth you specify).
-
-.. code:: sh
-
-   export MY_APP_SECTION1_VALUE1=test1
-   export MY_APP_SECTION2_VALUE2=test2
-   export MY_APP_SECTION2_VALUE3=test3
-   export MY_APP_SECTION2_SUBSECTION_VALUE4=test4
-
-.. code:: python
-
-   settings_map = Settings(prefix='MY_APP', implicit_depth=2)
-   print(dict(settings_map))
-
-   {
-       'section1': {
-           'value1': 'test1'
-       },
-       'section2': {
-           'value2': 'test2',
-           'value3': 'test3',
-           'subsection': {
-               'value4': 'test4'
-           }
-       }
-   }
-
-
 Settings file support
 ---------------------
 
@@ -163,6 +132,9 @@ In the following documentation examples, yaml files will be used, but any
 examples will work using the other file syntaxes as well.
 
 
+Advanced Features
+-----------------
+
 Setting variables whos values are saved in files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -189,6 +161,33 @@ or using an environment variable:
 
 will both write the content of the file at `"/home/myuser/supersecret.txt"`
 into the variable `section1 -> subsection1`.
+
+
+Setting variables whos values are saved in specific environment variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Similarly, to read a value from an environment variable, add a `"_from_env"` to
+the variable name. For example if we wanted to obtain a value from the variable
+`SPECIFIC_ENV_VAR`:
+
+.. code-block:: sh
+
+   export SPECIFIC_ENV_VAR="some value"
+
+Using a settings file with the contents (in this case yaml):
+
+.. code-block:: yaml
+
+   section1:
+     subsection1_from_env: SPECIFIC_ENV_VAR
+
+or using an environment variable:
+
+.. code-block:: sh
+
+   export MY_APP_SECTION1_SUBSECTION1_FROM_FILE="/home/myuser/supersecret.txt"
+
+will both write "some value" into the variable `section1 -> subsection1`.
 
 
 Nested settings files
@@ -227,10 +226,11 @@ which would result in a settings structure:
    }
 
 
-
+Integrations
+------------
 
 Command line support using click
---------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The click_ library is a great tool for creating command line applications. If
 you don't want to have to use an environment to set your configuration file.
@@ -261,6 +261,32 @@ with the last file overriting any overlapping keys of the first file.
 
    pip install click
    python cli.py --settings ./my_settings_file.toml  --settings ./my_settings_file.yaml
+
+
+Logging
+^^^^^^^
+
+If you have a "logging" section in your settings files, you can configure
+python standard library logging using that section directly:
+
+.. code:: yml
+
+   logging:
+     formatters:
+       default:
+         format': "%(levelname)s > %(message)s"
+     root:
+       level: DEBUG
+
+
+.. code:: python
+
+   import logging
+
+   settings_map = Settings(prefix='MY_APP')
+   settings_map.setup_logging()
+   logging.debug('test')
+   # outputs: DEBUG > test
 
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,19 @@ CLIMATECONTROL controls your applications settings and configuration
 environment. It is a Python library for loading app configurations from files
 and/or namespaced environment variables.
 
+Features
+--------
+
+* Separation of settings and code
+* Loading from files (`.yaml`, `.json`, `.toml`)
+* Loading multiple files using glob syntax
+* Loading from environment variables, including loading of nested values
+* Freely reference nested configurations via files or environment variables
+* CLI integration
+* Validation using the Validation library of your choice
+* Logging configuration integration
+* Testing integration
+
 
 Install
 -------
@@ -135,8 +148,8 @@ examples will work using the other file syntaxes as well.
 Advanced Features
 -----------------
 
-Setting variables whos values are saved in files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Setting variables from values saved in files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes we don't want to save values in plain text in environment files or in
 the settings file itself. Instead we have a file that contains the value of the
@@ -163,8 +176,8 @@ will both write the content of the file at `"/home/myuser/supersecret.txt"`
 into the variable `section1 -> subsection1`.
 
 
-Setting variables whos values are saved in specific environment variables
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Setting variables from values saved in specific environment variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Similarly, to read a value from an environment variable, add a `"_from_env"` to
 the variable name. For example if we wanted to obtain a value from the variable
@@ -310,12 +323,6 @@ temporarily:
        print(settings_map['a'])  # outputs: 2
    # After the context exits the settings map
    print(settings_map['a'])  # outputs: 1
-
-
-Python version support
-----------------------
-
-Do to the use of modern python features, only python 3.5 and above are supported.
 
 
 .. |Build Status| image:: https://travis-ci.org/daviskirk/climatecontrol.svg?branch=master

--- a/climatecontrol/env_parser.py
+++ b/climatecontrol/env_parser.py
@@ -5,9 +5,8 @@ import logging
 import os
 from typing import Any, Dict, Iterator, Mapping, NamedTuple, Sequence, Set
 
-from .file_loaders import load_from_filepath_or_content
+from . import file_loaders
 from .utils import update_nested
-
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +56,7 @@ class EnvParser:
     """
 
     def __init__(self,
-                 prefix: str = 'APP_SETTINGS',
+                 prefix: str = 'CLIMATECONTROL',
                  split_char: str = '_',
                  implicit_depth: int = 0,
                  settings_file_suffix: str = 'SETTINGS_FILE',
@@ -201,7 +200,8 @@ class EnvParser:
         if include_file:
             settings_file = os.environ.get(self.settings_file_env_var)
             if settings_file:
-                yield EnvSetting(self.settings_file_env_var, load_from_filepath_or_content(settings_file))
+                for fragment in file_loaders.iter_load(settings_file):
+                    yield EnvSetting(self.settings_file_env_var, fragment.data)
         if include_vars:
             for env_var in os.environ:
                 nested_keys = list(self._iter_nested_keys(env_var))

--- a/climatecontrol/file_loaders.py
+++ b/climatecontrol/file_loaders.py
@@ -9,6 +9,7 @@ from typing import Tuple, Iterator, List  # noqa: F401
 from typing import Any, Dict, Mapping, NamedTuple
 
 from .exceptions import NoCompatibleLoaderFoundError
+from .fragment import Fragment
 
 try:
     import toml
@@ -18,9 +19,6 @@ try:
     import yaml
 except ImportError:
     yaml = None  # type: ignore
-
-
-Fragment = NamedTuple('Fragment', [('data', Dict[str, Any]), ('source', str)])
 
 
 def iter_load(path_or_content: str) -> Iterator[Fragment]:
@@ -49,11 +47,11 @@ def iter_load(path_or_content: str) -> Iterator[Fragment]:
     globbed_files = glob.glob(expanded_path_or_content)  # type: List[str]
     if globbed_files:
         for filepath in sorted(globbed_files):
-            yield Fragment(data=load_from_filepath(filepath), source=filepath)
+            yield Fragment(value=load_from_filepath(filepath), source=filepath)
         return
 
     # assume content if no files were found
-    yield Fragment(data=load_from_content(path_or_content), source='content')
+    yield Fragment(value=load_from_content(path_or_content), source='content')
 
 
 def load_from_content(content: str) -> Dict[str, Any]:

--- a/climatecontrol/file_loaders.py
+++ b/climatecontrol/file_loaders.py
@@ -1,12 +1,12 @@
 """Module for loading various file formats."""
 
+import glob
 import json
 import os
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-import glob
 from typing import Tuple, Iterator, List  # noqa: F401
-from typing import Any, Dict, Mapping, NamedTuple
+from typing import Any, Dict, Mapping
 
 from .exceptions import NoCompatibleLoaderFoundError
 from .fragment import Fragment
@@ -43,6 +43,8 @@ def iter_load(path_or_content: str) -> Iterator[Fragment]:
             this filepath or content type.
 
     """
+    if not path_or_content:
+        return
     expanded_path_or_content = os.path.expanduser(os.path.expandvars(path_or_content))
     globbed_files = glob.glob(expanded_path_or_content)  # type: List[str]
     if globbed_files:

--- a/climatecontrol/file_loaders.py
+++ b/climatecontrol/file_loaders.py
@@ -4,8 +4,9 @@ import json
 import os
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Tuple, List  # noqa: F401
-from typing import Any, Dict, Mapping
+import glob
+from typing import Tuple, Iterator, List  # noqa: F401
+from typing import Any, Dict, Mapping, NamedTuple
 
 from .exceptions import NoCompatibleLoaderFoundError
 
@@ -19,36 +20,16 @@ except ImportError:
     yaml = None  # type: ignore
 
 
-def load_from_filepath(filepath: str, allow_unknown_file_type=False):
-    """Read settings file from a filepath.
-
-    Returns:
-        Data structure loaded/parsed from a compatible `FileLoader`. If no
-        compatible file loaded can be found and `allow_unknown_file_type` is
-        set, return the raw file contents (if `allow_unknown_file_type` is not
-        set we raise an error on this case).
-
-    Raises:
-        SettingsLoadError
-
-    """
-    try:
-        return load_from_filepath_or_content(filepath, _allow_content=False)
-    except NoCompatibleLoaderFoundError:
-        if not allow_unknown_file_type:
-            raise
-        # Load the raw contents from file and assume that they are to be
-        # interpreted as a raw string.
-        with open(filepath) as f:
-            return f.read().strip()
+Fragment = NamedTuple('Fragment', [('data', Dict[str, Any]), ('source', str)])
 
 
-def load_from_filepath_or_content(path_or_content: str, _allow_content=True) -> Dict[str, Any]:
+def iter_load(path_or_content: str) -> Iterator[Fragment]:
     """Read settings file from a filepath or from a string representing the file contents.
 
-    If ``path_or_content`` is a valid filename, load the file. If
-    ``path_or_content`` represents a json, yaml or toml string instead (the
-    contents of a json/toml/yaml file), parse the string directly.
+    If ``path_or_content`` is a valid filename or glob expression, load the
+    file (or all matching files). If ``path_or_content`` represents a json,
+    yaml or toml string instead (the contents of a json/toml/yaml file), parse
+    the string directly.
 
     Note that json, yaml and toml files are read. If ``path_or_content`` is a
     string, we will try to guess what file type you meant. Note that this last
@@ -64,18 +45,59 @@ def load_from_filepath_or_content(path_or_content: str, _allow_content=True) -> 
             this filepath or content type.
 
     """
+    expanded_path_or_content = os.path.expanduser(os.path.expandvars(path_or_content))
+    globbed_files = glob.glob(expanded_path_or_content)  # type: List[str]
+    if globbed_files:
+        for filepath in sorted(globbed_files):
+            yield Fragment(data=load_from_filepath(filepath), source=filepath)
+        return
+
+    # assume content if no files were found
+    yield Fragment(data=load_from_content(path_or_content), source='content')
+
+
+def load_from_content(content: str) -> Dict[str, Any]:
+    """Read settings from a content string."""
     file_data = {}  # type: Dict
-    if not path_or_content:
+    if not content:
         return file_data
     for loader in FileLoader.registered_loaders:
-        if loader.is_path(path_or_content):
-            file_data = loader.from_path(path_or_content)
-            break
-        if _allow_content and loader.is_content(path_or_content):
-            file_data = loader.from_content(path_or_content)
+        if loader.is_content(content):
+            file_data = loader.from_content(content)
             break
     else:
-        raise NoCompatibleLoaderFoundError('Failed to load settings. No compatible loader: {}'.format(path_or_content))
+        raise NoCompatibleLoaderFoundError(
+            'Failed to load settings from content. No compatible loader: {}'
+            .format(content)
+        )
+    return file_data
+
+
+def load_from_filepath(filepath: str) -> Dict[str, Any]:
+    """Read settings file from a filepath or from a string representing the file contents.
+
+    Args:
+        filepath: Path to file or file contents
+
+    Raises:
+        FileLoadError: when an error occurs during the loading of a file.
+        ContentLoadError: when an error occurs during the loading of file contents.
+        NoCompatibleLoaderFoundError: when no compatible loader was found for
+            this filepath or content type.
+
+    """
+    file_data = {}  # type: Dict
+    if not filepath:
+        return file_data
+    for loader in FileLoader.registered_loaders:
+        if loader.is_path(filepath):
+            file_data = loader.from_path(filepath)
+            break
+    else:
+        raise NoCompatibleLoaderFoundError(
+            'Failed to load settings from filepath. '
+            'No compatible loader for file: {}'.format(filepath)
+        )
     return file_data
 
 

--- a/climatecontrol/fragment.py
+++ b/climatecontrol/fragment.py
@@ -1,0 +1,199 @@
+"""Module for defining settings fragments."""
+
+from copy import deepcopy
+from enum import Enum
+from itertools import zip_longest
+from typing import Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+from .utils import EMPTY, get_nested, merge_nested
+
+
+class FragmentKind(Enum):
+    """Fragment kind."""
+
+    MERGE = 'MERGE'
+    REMOVE = 'REMOVE'
+
+
+class FragmentPath(Sequence):
+    """Path indicating nested levels of a fragment value."""
+
+    def __init__(self, iterable: Iterable = ()):
+        """Assign initial iterable data."""
+        self._data: list = list(iterable)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator:
+        yield from self._data
+
+    def __getitem__(self, index) -> Any:
+        return self._data[index]
+
+    def __repr__(self) -> str:
+        return '{}({})'.format(type(self).__qualname__, repr(self._data))
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self._data == other._data
+
+    def expand(self, value=EMPTY):
+        """Expand path to object.
+
+        Depending on each entry of the path a dictionary or list is created.
+        Entries that are not defined are will with the :data:`EMPTY` object.
+
+        Example:
+
+            >>> FragmentPath(['a', 1, 'b']).expand()
+            {'a': [<EMPTY>, {'b': <EMPTY>}]}
+
+        """
+        if self._data and self._is_list_index(self._data[0]):
+            new_value = [EMPTY] * (self._data[0] + 1)
+        else:
+            new_value = {}
+        sub_value = new_value
+        for subpath, next_subpath in zip_longest(self._data[:-1], self._data[1:]):
+            if self._is_list_index(next_subpath):
+                sub_value[subpath] = [EMPTY] * (next_subpath + 1)
+            else:
+                sub_value[subpath] = {}
+            sub_value = sub_value[subpath]
+
+        # last path value holds the actual value
+        if self._data:
+            sub_value[self._data[-1]] = value
+
+        return new_value
+
+    def common(self, other: Sequence) -> 'FragmentPath':
+        """Given another sequence representing a path, return the part of the sequence up to the point where they first differ."""
+        common_path: List = []
+        other_path: FragmentPath = type(self)(other)
+        for subpath, subpath_other in zip(self._data, other_path):
+            if subpath == subpath_other:
+                common_path.append(subpath)
+            else:
+                break
+        return type(self)(common_path)
+
+    def _is_list_index(self, index) -> bool:
+        """Check if index is a list index."""
+        return isinstance(index, int)
+
+
+class Fragment:
+    """Data fragment for storing a value and metadata related to it."""
+
+    value: Any
+    source: str
+    path: FragmentPath
+    kind: FragmentKind
+
+    def __init__(self, value: Any,
+                 source: str = None,
+                 path: Iterable = None,
+                 kind: FragmentKind = None) -> None:
+        """Initialize fragment."""
+        if isinstance(value, Fragment):
+            fragment = value
+            value = fragment.value
+            source = fragment.source
+            path = fragment.path
+            kind = fragment.kind
+
+        if isinstance(path, str):
+            path = path.split('.')
+
+        self.value = value
+        self.source = source if source is not None else ''
+        self.path = FragmentPath(path) if path is not None else FragmentPath()
+        self.kind = kind if kind is not None else FragmentKind.MERGE
+
+    def __repr__(self):
+        return '{}(value={}, source={}, path={}, kind={})'.format(
+            type(self).__qualname__,
+            repr(self.value),
+            repr(self.source),
+            repr(self.path),
+            repr(self.kind)
+        )
+
+    def __eq__(self, other):
+        return (
+            type(self) == type(other) and
+            self.value == other.value and
+            self.source == other.source and
+            self.path == other.path and
+            self.kind == other.kind
+        )
+
+    def iter_leaves(self) -> Iterator['Fragment']:
+        """Iterate over all leaves of a fragment.
+
+        A leaf is obtained by walking through any nested dictionaries until a
+        non-dictionary value is found.
+
+        """
+        items: Iterable[tuple]
+        if isinstance(self.value, Mapping):
+            items = self.value.items()
+        elif isinstance(self.value, Sequence) and not isinstance(self.value, str):
+            items = enumerate(self.value)
+        else:
+            # Can't obtain any items so just assume this is a leaf
+            yield self
+            return
+
+        for k, v in items:
+            yield from self.clone(value=v, path=list(self.path) + [k]).iter_leaves()
+
+    def expand_value_with_path(self) -> Any:
+        """Create expanded dictionary where the fragments path acts as nested keys."""
+        return self.path.expand(self.value)
+
+    def merge(self, other: 'Fragment') -> 'Fragment':
+        """Merge with another fragment."""
+        expanded_value = self.expand_value_with_path()
+        other_expanded_value = other.expand_value_with_path()
+        merged_value = merge_nested(expanded_value, other_expanded_value)
+
+        new_path = self.path.common(other.path)
+        new_value = get_nested(merged_value, new_path)
+        new_source = ', '.join(str(s) for s in [self.source, other.source] if s)
+
+        return self.clone(value=new_value, source=new_source, path=new_path)
+
+    def difference(self, fragment: 'Fragment') -> 'Fragment':
+        """Delete a fragments elements from the current fragment."""
+        expanded_value = deepcopy(self.expand_value_with_path())
+
+        for leaf in fragment.iter_leaves():
+            if leaf.path:
+                submap = get_nested(expanded_value, leaf.path[:-1])
+                del submap[leaf.path[-1]]
+
+        new_value = get_nested(expanded_value, self.path)
+
+        return self.clone(value=new_value)
+
+    def apply(self, fragment: 'Fragment'):
+        """Apply a second fragment according to it's "kind"."""
+        if fragment.kind == FragmentKind.MERGE:
+            return self.merge(fragment)
+        elif fragment.kind == FragmentKind.REMOVE:
+            return self.difference(fragment)
+        else:
+            raise ValueError('Can\'t apply fragment with kind: {}'.format(fragment.kind))
+
+    def clone(self, **kwargs):
+        """Clone fragment but using ``kwargs`` as alternative constructor arguments."""
+        defaults = {
+            'value': self.value,
+            'source': self.source,
+            'path': self.path,
+            'kind': self.kind,
+        }
+        updated_kwargs = {**defaults, **kwargs}
+        return type(self)(**updated_kwargs)

--- a/climatecontrol/settings_parser.py
+++ b/climatecontrol/settings_parser.py
@@ -1,14 +1,18 @@
 """Settings parser."""
 
-import json
+from enum import Enum
+import itertools
 import logging
+import warnings
 import os
 from contextlib import contextmanager
 from copy import deepcopy
 from pprint import pformat
-from typing import List, Type, TypeVar, Tuple # noqa F401
-from typing import (cast, Any, Callable, List, Sequence,
-                    Optional, Union, Mapping, Dict, Iterator)
+from typing import (  # noqa: F401
+    Any, Callable, Dict, Iterable, Iterator, List,
+    Mapping, MutableMapping, MutableSequence, Optional,
+    Sequence, TypeVar, Union, cast
+)
 
 try:
     import click
@@ -20,9 +24,9 @@ from .exceptions import SettingsValidationError  # noqa: F401  # Import here for
 from .file_loaders import (
     FileLoader, NoCompatibleLoaderFoundError, iter_load, load_from_filepath
 )
-from .fragment import Fragment, FragmentKind
+from .fragment import Fragment
 from .logtools import DEFAULT_LOG_SETTINGS, logging_config
-from .utils import iter_hierarchy, merge_nested
+from .utils import merge_nested, parse_as_json_if_possible
 
 
 logger = logging.getLogger(__name__)
@@ -42,14 +46,14 @@ class Settings(Mapping):
             result of the settings. The function should take a single
             nested dictionary argument (the settings map) as an argument
             and output a nested dictionary.
-        update_on_init: If set to `False` no parsing is performed upon
+        update_on_init: (Deprecated) If set to `False` no parsing is performed upon
             initialization of the object. You will need to call update
             manually if you want load use any settings.
 
     Args:
         settings_files: See attribute
         parser: See attribute
-        update_on_init: If set to ``True``, read all configurations upon initialization.
+        update_on_init: (Deprecated) If set to ``True``, read all configurations upon initialization.
         **env_parser_kwargs: Arguments passed to :class:`EnvParser` constructor.
 
     Example:
@@ -58,8 +62,8 @@ class Settings(Mapping):
         >>> os.environ['MY_APP_SECTION1_SUB1'] = 'test1'
         >>> os.environ['MY_APP_SECTION2_SUB2'] = 'test2'
         >>> os.environ['MY_APP_SECTION2_SUB3'] = 'test3'
-        >>> settings_manager = SettingsManager(prefix='MY_APP', implicit_depth=1)
-        >>> settings_manager.settings
+        >>> settings_manager = SettingsManager(prefix='MY_APP')
+        >>> dict(settings_manager)
         {'value0': 'test0', 'section1': {'subsection1': 'test1'}, 'section2': {'sub2': 'test2', 'sub3': 'test3'}}
 
     See Also:
@@ -68,9 +72,9 @@ class Settings(Mapping):
     """
 
     def __init__(self,
-                 settings_files: Optional[Sequence[str]] = None,
-                 parser: Optional[Callable] = None,
-                 update_on_init: bool = True,
+                 settings_files: Sequence[str] = (),
+                 parser: Optional[Callable[[Mapping], Mapping]] = None,
+                 update_on_init: Optional[bool] = None,
                  **env_parser_kwargs) -> None:
         """Initialize settings object."""
         self.env_parser = EnvParser(**(env_parser_kwargs or {}))
@@ -78,8 +82,11 @@ class Settings(Mapping):
         self.settings_files = settings_files
         self.update_data = {}  # type: dict
         self.fragments = []  # type: List[Fragment]
-        self._data = {}  # type: dict
+        self._data = {}  # type: Mapping
+        self._initialized = False  # type: bool
 
+        if update_on_init is not None:
+            warnings.warn('setting update_on_init is deprecated', DeprecationWarning)
         if update_on_init:
             self.update()
 
@@ -90,18 +97,22 @@ class Settings(Mapping):
         return len(self._data)
 
     def __getitem__(self, key: str) -> Any:
+        if not self._initialized:
+            self.update()
         return self._data[key]
 
     def __iter__(self) -> Iterator[str]:
+        if not self._initialized:
+            self.update()
         yield from self._data
 
     @property
-    def parser(self) -> Optional[Callable]:
+    def parser(self) -> Optional[Callable[[Mapping], Mapping]]:
         """Return settings parser function."""
         return self._parse
 
     @parser.setter
-    def parser(self, value: Optional[Callable]) -> None:
+    def parser(self, value: Optional[Callable[[Mapping], Mapping]]) -> None:
         """Set the settings parser function."""
         if value and not callable(value):
             raise TypeError('If given, ``parser`` must be a callable')
@@ -113,14 +124,28 @@ class Settings(Mapping):
         return self._settings_files
 
     @settings_files.setter
-    def settings_files(self, files: Sequence) -> None:
+    def settings_files(self, files: Union[str, Iterable[str]]) -> None:
         """Set settings files to use when parsing settings."""
         files = files or ()
         if isinstance(files, str):
             files = (files,)
         self._settings_files = list(files)
 
-    def update(self, d: Optional[Union[Mapping, Dict]] = None, clear: bool = False) -> None:
+    @property
+    def update_log(self) -> str:
+        """Log of all each loaded settings variable."""
+        def iter_fragment_lines(fragment: Fragment) -> Iterator[str]:
+            for leaf in fragment.iter_leaves():
+                action = 'removed' if leaf.value == REMOVED else 'loaded'
+                yield action + ' ' + '.'.join(str(p) for p in leaf.path) + ' from ' + str(leaf.source)
+
+        lines = itertools.chain.from_iterable(
+            iter_fragment_lines(fragment) for fragment in self.fragments
+        )
+        result = '\n'.join(lines)
+        return result
+
+    def update(self, d: Optional[Mapping] = None, clear: bool = False) -> None:
         """Update object settings and reload files and environment variables.
 
         Args:
@@ -151,36 +176,35 @@ class Settings(Mapping):
         # Compile a list of fragments
         fragments = []
 
-        for fragment in self._iter_load_files():
-            for processed_fragment in self.process_fragment(fragments):
-                fragments.append(processed_fragment)
-
-        for fragment in self.env_parser.iter_load():
-            fragments.append(Fragment)
-
-        fragments.append(Fragment(value=update_data, source='external'))
+        for fragment in itertools.chain(
+                self._iter_load_files(),
+                self.env_parser.iter_load(),
+                [Fragment(value=update_data, source='external')]
+        ):
+            fragments.append(fragment)
+            fragments.extend(self.process_fragment(fragment))
 
         # Combine the fragments into one final fragment
         combined_fragment = None  # type: Optional[Fragment]
-        fragment_iterator = iter(fragments)
-        for fragment in fragment_iterator:
+        for fragment in fragments:
             if combined_fragment is None:
-                if fragment.kind == FragmentKind.MERGE:
-                    combined_fragment = fragment
-                continue
-            combined_fragment = combined_fragment.apply(fragment)
+                combined_fragment = fragment
+            else:
+                combined_fragment = combined_fragment.merge(fragment)
 
         # Obtain settings map
         if combined_fragment is None:
             settings_map = {}  # type: dict
         else:
-            settings_map = fragment.expand_value_with_path()
+            settings_map = combined_fragment.expand_value_with_path()
+            clean_removed_items(settings_map)
 
         self._data = self.parse(settings_map)
 
         # If parsing was successfull, update external data and fragments.
         self.update_data = update_data
         self.fragments = fragments
+        self._initialized = True
 
     def parse(self, data: Mapping) -> Mapping:
         """Parse data into settings.
@@ -211,15 +235,20 @@ class Settings(Mapping):
             logging_settings = merge_nested(logging_settings, logging_settings_update)
         logging_config.dictConfig(logging_settings)
 
-    def click_settings_file_option(self, **kw) -> Callable:
+    def click_settings_file_option(self, **kw) -> Callable[..., Any]:
         """See :func:`cli_utils.click_settings_file_option`."""
         from . import cli_utils
         return cli_utils.click_settings_file_option(self, **kw)
 
-    def process_fragment(self, fragment: Fragment) -> Fragment:
+    def process_fragment(self, fragment: Fragment) -> Iterator[Fragment]:
         """Preprocess a settings fragment and return the new version."""
-
-        return Fragment(value=replace_from_file_vars(fragment.data), source=fragment.source)
+        processors = [
+            replace_from_file_vars, replace_from_env_vars
+        ]  # type: List[Callable[[Fragment], Iterator[Fragment]]]
+        for process in processors:
+            for new_fragment in process(fragment):
+                yield new_fragment
+                yield from self.process_fragment(new_fragment)
 
     def to_config(self, *, save_to: str = None, style: str = '.json') -> Optional[str]:
         """Generate a settings file from the current settings."""
@@ -227,7 +256,7 @@ class Settings(Mapping):
             style = os.path.splitext(save_to)[1]
         for loader in FileLoader.registered_loaders:
             if style in loader.valid_file_extensions:
-                s = loader.to_content(self._data)
+                s = loader.to_content(dict(self))
                 break
         else:
             raise ValueError('Not a valid style / file extension: {}'.format(style))
@@ -257,76 +286,114 @@ class Settings(Mapping):
 
         """
         archived_settings = deepcopy(self._data)
-        archived_settings_files = deepcopy(self._settings_files)
+        archived_settings_files = deepcopy(self.settings_files)
         archived_update_data = deepcopy(self.update_data)
         yield self
         self._data = archived_settings
-        self._settings_files = archived_settings_files
+        self.settings_files = archived_settings_files
         self.update_data = archived_update_data
 
     def _iter_load_files(self) -> Iterator[Fragment]:
         for entry in self.settings_files:
             yield from iter_load(entry)
 
-    def _log_assignments(self, fragment: Fragment) -> None:
-        messages = []
-        for levels in iter_hierarchy(fragment.data):
-            if levels:
-                message = '.'.join(levels)
-                messages.append(message)
-        if messages:
-            logger.debug('Assigned settings%s: %s',
-                         ' from ' + str(fragment.source) if fragment.source else '',
-                         json.dumps(messages))
+
+def replace_from_env_vars(fragment: Fragment, postfix_trigger: str = '_from_env') -> Iterator[Fragment]:
+    """Read and replace settings values from environment variables.
+
+    Args:
+        fragment: Fragment to process
+        postfix_trigger: Optionally configurable string to trigger a
+            replacement with an environment variable. If a key is found which
+            ends with this string, the value is assumed to be the name of an
+            environemtn variable and the settings value will be set to the
+            contents of that variable.
+
+    Yields:
+        Additional fragments to patch the original fragment.
+
+    """
+    for leaf in fragment.iter_leaves():
+        if not leaf.path or leaf.value == REMOVED:
+            continue
+        key, value = leaf.path[-1], leaf.value
+        if isinstance(value, str) and isinstance(key, str) and key.lower().endswith(postfix_trigger):
+            env_var = value
+            yield leaf.clone(value=REMOVED)
+            try:
+                env_var_value = os.environ[env_var]
+            except KeyError as e:
+                logger.info('Error while trying to load environment variable: %s. (%s) Skipping...',
+                            env_var, e)
+            else:
+                new_key = key[:-len(postfix_trigger)]
+                new_value = parse_as_json_if_possible(env_var_value)
+                yield leaf.clone(value=new_value, path=list(leaf.path[:-1]) + [new_key])
 
 
-def replace_from_file_vars(fragment: Fragment, postfix_trigger: str = '_from_file') -> Fragment:
+def replace_from_file_vars(fragment: Fragment, postfix_trigger: str = '_from_file') -> Iterator[Fragment]:
     """Read and replace settings values from content local files.
 
     Args:
-        data: Given subset of settings data (or entire settings mapping)
+        fragment: Fragment to process
         postfix_trigger: Optionally configurable string to trigger a local
             file value. If a key is found which ends with this string, the
             value is assumed to be a file path and the settings value will
             be set to the content of the file.
 
-    Returns:
-        An updated copy of `data` with keys and values replaced accordingly.
+    Yields:
+        Additional fragments to patch the original fragment.
 
     """
-    if not fragment.value:
-        yield fragment
-        return
-    elif isinstance(fragment.value, Mapping):
-        new_data = {k: v for k, v in data.items()}  # type: Any
-        items = tuple(data.items())
-    elif isinstance(data, Sequence) and not isinstance(data, str):
-        new_data = [item for item in data]
-        items = tuple(enumerate(data))
-    else:
-        return cast(T, data)
-    for k, v in items:
-        if isinstance(v, str) and isinstance(k, str) and k.lower().endswith(postfix_trigger):
-            key_with_postfix = k
-            filepath = v
-            # Reassign value (v) using the contents of the file.
+    for leaf in fragment.iter_leaves():
+        if not leaf.path or leaf.value == REMOVED:
+            continue
+        key, value = leaf.path[-1], leaf.value
+        if isinstance(value, str) and isinstance(key, str) and key.lower().endswith(postfix_trigger):
+            filepath = value
+            yield leaf.clone(value=REMOVED)
             try:
                 try:
-                    v = load_from_filepath(filepath)
+                    new_value = load_from_filepath(filepath)  # type: Any
                 except NoCompatibleLoaderFoundError:
                     # just load as plain text file and interpret as string
                     with open(filepath) as f:
-                        v = f.read().strip()
+                        new_value = f.read().strip()
             except FileNotFoundError as e:
                 logger.info('Error while trying to load variable from file: %s. (%s) Skipping...',
                             filepath, e)
             else:
-                k = k[:-len(postfix_trigger)]  # Use the "actual" key from here on.
-                new_data[k] = v
-                logger.info('Settings key %s set to contents of file "%s"', k, filepath)
-            finally:
-                del new_data[key_with_postfix]
-        if isinstance(v, (Mapping, Sequence)) and not isinstance(v, str):
-            parsed_v = replace_from_file_vars(v)
-            new_data[k] = parsed_v
-    return new_data
+                new_key = key[:-len(postfix_trigger)]
+                yield leaf.clone(value=new_value, path=list(leaf.path[:-1]) + [new_key])
+
+
+def clean_removed_items(obj):
+    """Remove all keys that contain a removed key indicated by a :data:``REMOVED`` object."""
+    if isinstance(obj, MutableMapping):
+        items = obj.items()  # type: Any
+    elif isinstance(obj, MutableSequence):
+        items = enumerate(obj)
+    else:
+        return
+
+    keys_to_remove = []
+    for key, value in items:
+        if value == REMOVED:
+            keys_to_remove.append(key)
+        else:
+            clean_removed_items(value)
+
+    for key in keys_to_remove:
+        del obj[key]
+
+
+class _Removed(Enum):
+    """Object representing an empty item."""
+
+    REMOVED = None
+
+    def __repr__(self):
+        return '<REMOVED>'  # pragma: nocover
+
+
+REMOVED = _Removed.REMOVED

--- a/climatecontrol/settings_parser.py
+++ b/climatecontrol/settings_parser.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from pprint import pformat
 from typing import List, Type, TypeVar, Tuple # noqa F401
 from typing import (cast, Any, Callable, Sequence,
-                    Optional, Union, Mapping, Dict, Iterator, NamedTuple)
+                    Optional, Union, Mapping, Dict, Iterator)
 
 try:
     import click
@@ -17,16 +17,15 @@ except ImportError:
 
 from .env_parser import EnvParser
 from .exceptions import SettingsValidationError  # noqa: F401  # Import here for backwards compatability.
-from .file_loaders import FileLoader, load_from_filepath, load_from_filepath_or_content
+from .file_loaders import (
+    FileLoader, Fragment, NoCompatibleLoaderFoundError, iter_load, load_from_filepath
+)
 from .logtools import DEFAULT_LOG_SETTINGS, logging_config
 from .utils import iter_hierarchy, update_nested
 
 
 logger = logging.getLogger(__name__)
 T = TypeVar('T')
-
-
-Fragment = NamedTuple('Fragment', [('data', Dict[str, Any]), ('source', str)])
 
 
 class Settings(Mapping):
@@ -246,7 +245,7 @@ class Settings(Mapping):
         self._settings_files = archived_settings_files
         self.update_data = archived_update_data
 
-    def _render_from_file_vars(self, data: T, postfix_trigger='_from_file') -> T:
+    def _render_from_file_vars(self, data: T, postfix_trigger: str = '_from_file') -> T:
         """Read and replace settings values from content local files.
 
         Args:
@@ -276,7 +275,12 @@ class Settings(Mapping):
                 filepath = v
                 # Reassign value (v) using the contents of the file.
                 try:
-                    v = load_from_filepath(filepath, allow_unknown_file_type=True)
+                    try:
+                        v = load_from_filepath(filepath)
+                    except NoCompatibleLoaderFoundError:
+                        # just load as plain text file and interpret as string
+                        with open(filepath) as f:
+                            v = f.read().strip()
                 except FileNotFoundError as e:
                     logger.info('Error while trying to load variable from file: %s. (%s) Skipping...',
                                 filepath, e)
@@ -292,9 +296,8 @@ class Settings(Mapping):
         return new_data
 
     def _iter_load_files(self) -> Iterator[Fragment]:
-        for settings_file in self.settings_files:
-            file_update = load_from_filepath_or_content(settings_file)
-            yield Fragment(data=file_update, source=str(settings_file))
+        for entry in self.settings_files:
+            yield from iter_load(entry)
 
     def _log_assignments(self, fragment: Fragment) -> None:
         messages = []

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,15 @@
 name: climatecontrol
 dependencies:
-  - python=3.6
+  - python=3.8
+  - pip=19
   - pyyaml
-  - pip
+  - click
+  - pytest
+  - pytest-mock
+  - pytest-cov
+  - toml
+  - flake8
+  - mypy
+  - ipython
   - pip:
-    - toml~=0.9.3.0
+    - pdbpp

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,10 @@
 import os
 from setuptools import setup
 
-requirements = [
-    'typing'
-]
+requirements = []  # type: list
 
 test_requirements = [
-    'pytest>=3.2.1,<4.0.0',
+    'pytest',
     'pytest-mock',
     'pytest-cov>=2.5.1',
     'toml>=0.9.2',
@@ -20,23 +18,11 @@ test_requirements = [
 
 rootdir = os.path.abspath(os.path.dirname(__file__))
 
-
-def read(fname):
-    """Read a file from path.
-
-    Utility function to read the README file. Used for the long_description.
-    It's nice, because now 1) we have a top level README file and 2) it's
-    easier to type in the README file than to put a raw string in below ...
-
-    """
-    return open(os.path.join(rootdir, fname)).read()
-
-
 setup(
     name='climatecontrol',
     use_scm_version=True,
     description='Python library for loading app configurations from files and/or namespaced environment variables',
-    long_description=read('README.rst'),
+    long_description=open(os.path.join(rootdir, 'README.rst')).read(),
     author='Davis Kirkendall',
     author_email='davis.e.kirkendall@gmail.com',
     url='https://github.com/daviskirk/climatecontrol',
@@ -58,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     setup_requires=['pytest-runner', 'setuptools_scm'],
     tests_require=test_requirements

--- a/tests/test_env_parser.py
+++ b/tests/test_env_parser.py
@@ -1,10 +1,12 @@
 """Test settings."""
 
 import os
+import sys
 
 import pytest
 
 from climatecontrol.env_parser import EnvParser  # noqa: I100
+from climatecontrol.fragment import Fragment
 
 
 @pytest.mark.parametrize('attr, value, expected', [
@@ -12,7 +14,7 @@ from climatecontrol.env_parser import EnvParser  # noqa: I100
     ('settings_file_suffix', 'suffix2', 'suffix2'),
     ('settings_file_env_var', 'wrongval', None),
 ])
-def test_env_parser_assign(mock_empty_os_environ, attr, value, expected):
+def test_envparser_assign(mock_empty_os_environ, attr, value, expected):
     """Check that we can assign attributes of env parser."""
     s = EnvParser(prefix='this', settings_file_suffix='suffix')
     assert s.prefix == 'THIS_'
@@ -29,89 +31,64 @@ def test_env_parser_assign(mock_empty_os_environ, attr, value, expected):
             assert s.settings_file_env_var == 'THIS_' + expected.upper()
 
 
-@pytest.mark.parametrize('prefix, implicit_depth, split_char, expected', [
-    ('TEST_STUFF', 1, '_', {'testgroup': {'testvar': 7, 'test_var': 9}}),
-    ('TEST_STUFF', 1, '-', {}),
-    ('TEST_STUFF', 0, '_', {'testgroup': {'testvar': 7, 'test_var': 6}, 'testgroup_test_var': 9}),
-    ('TEST_STUFF_', 1, '_', {'testgroup': {'testvar': 7, 'test_var': 9}}),
-    ('TEST_STUFFING', 1, '_', {}),
+@pytest.mark.parametrize('prefix, implicit_depth, split_char, expected_kws', [
+    ('TEST_STUFF', 1, '_', [
+        dict(value=6, source='ENV:TEST_STUFF_TESTGROUP__TEST_VAR', path=['testgroup', 'test_var']),
+        dict(value=7, source='ENV:TEST_STUFF_TESTGROUP__TESTVAR', path=['testgroup', 'testvar']),
+        dict(value=9, source='ENV:TEST_STUFF_TESTGROUP_TEST_VAR', path=['testgroup', 'test_var'])
+    ]),
+    ('TEST_STUFF', 1, '-', []),
+    ('TEST_STUFF', 0, '_', [
+        dict(value=6, source='ENV:TEST_STUFF_TESTGROUP__TEST_VAR', path=['testgroup', 'test_var']),
+        dict(value=7, source='ENV:TEST_STUFF_TESTGROUP__TESTVAR', path=['testgroup', 'testvar']),
+        dict(value=9, source='ENV:TEST_STUFF_TESTGROUP_TEST_VAR', path=['testgroup_test_var'])
+    ]),
+    ('TEST_STUFF_', 1, '_', [
+        dict(value=6, source='ENV:TEST_STUFF_TESTGROUP__TEST_VAR', path=['testgroup', 'test_var']),
+        dict(value=7, source='ENV:TEST_STUFF_TESTGROUP__TESTVAR', path=['testgroup', 'testvar']),
+        dict(value=9, source='ENV:TEST_STUFF_TESTGROUP_TEST_VAR', path=['testgroup', 'test_var'])
+    ]),
+    ('TEST_STUFFING', 1, '_', []),
 ])
-def test_parse_environment_vars(mock_os_environ, prefix, implicit_depth, split_char, expected):
+def test_envparser_iter_load(mock_os_environ, prefix, implicit_depth, split_char, expected_kws):
     """Check that we can parse settings from variables."""
     env_parser = EnvParser(
         prefix=prefix,
         split_char=split_char,
         implicit_depth=implicit_depth)
-    results = [f.expand_value_with_path() for f in env_parser.iter_load()]
-    import pdb; pdb.set_trace()  # noqa: E702
+    expected = [Fragment(**kw) for kw in expected_kws]
+    results = list(env_parser.iter_load())
     assert results == expected
 
 
-@pytest.mark.parametrize('implicit_depth, environ, expected', [
+@pytest.mark.parametrize('environ, expected_kw', [
     (
-        1,
-        {
-            'TEST_STUFF_TESTGROUP_TEST_INT': '6',
-            'TEST_STUFF_TESTGROUP_TEST_ARRAY': '[4, 5, 6]',
-            'TEST_STUFF_TESTGROUP_TEST_RAW_STR': 'al//asdjk',
-            'TEST_STUFF_TESTGROUP_TEST_STR': '"[4, 5, 6]"',
-            'TEST_STUFF_TESTGROUP_TEST_AMQP': 'amqp://guest:guest@127.0.0.1:5672//'
-        },
-        {
-            'testgroup': {
-                'test_int': 6,
-                'test_array': [4, 5, 6],
-                'test_raw_str': 'al//asdjk',
-                'test_str': '[4, 5, 6]',
-                'test_amqp': 'amqp://guest:guest@127.0.0.1:5672//',
-            }
-        }
-    ),
-    (
-        2,
-        {
-            'TEST_STUFF_TESTGROUP_TEST_INT': '6',
-            'TEST_STUFF_TESTGROUP_TEST_ARRAY': '[4, 5, 6]',
-            'TEST_STUFF_TESTGROUP_TEST_RAW_STR': 'al//asdjk',
-            'TEST_STUFF_TESTGROUP_TEST_STR': '"[4, 5, 6]"',
-            'TEST_STUFF_TESTGROUP_TEST_AMQP': 'amqp://guest:guest@127.0.0.1:5672//'
-        },
-        {
-            'testgroup': {
-                'test': {
-                    'int': 6,
-                    'array': [4, 5, 6],
-                    'raw_str': 'al//asdjk',
-                    'str': '[4, 5, 6]',
-                    'amqp': 'amqp://guest:guest@127.0.0.1:5672//',
-                }
-            }
-        }
-    ),
-    (
-        -1,
         {
             'TEST_STUFF_TESTGROUP__TEST_INT': '6',
             'TEST_STUFF_TESTGROUP__TEST_ARRAY': '[4, 5, 6]',
             'TEST_STUFF_TESTGROUP__TEST_RAW_STR': 'al//asdjk',
             'TEST_STUFF_TESTGROUP__TEST_STR': '"[4, 5, 6]"',
-            'TEST_STUFF_TESTGROUP__TEST_AMQP': 'amqp://guest:guest@127.0.0.1:5672//'
+            'TEST_STUFF_TESTGROUP__TEST_COMPLEX_RAW_STR': 'amqp://guest:guest@127.0.0.1:5672//'
         },
-        {
-            'testgroup': {
-                'test_int': 6,
-                'test_array': [4, 5, 6],
-                'test_raw_str': 'al//asdjk',
-                'test_str': '[4, 5, 6]',
-                'test_amqp': 'amqp://guest:guest@127.0.0.1:5672//',
-            }
-        }
+        [
+            {'value': 6, 'source': 'ENV:TEST_STUFF_TESTGROUP__TEST_INT', 'path': ['testgroup', 'test_int']},
+            {'value': [4, 5, 6], 'source': 'ENV:TEST_STUFF_TESTGROUP__TEST_ARRAY', 'path': ['testgroup', 'test_array']},
+            {'value': 'al//asdjk', 'source': 'ENV:TEST_STUFF_TESTGROUP__TEST_RAW_STR', 'path': ['testgroup', 'test_raw_str']},  # noqa: E501
+            {'value': '[4, 5, 6]', 'source': 'ENV:TEST_STUFF_TESTGROUP__TEST_STR', 'path': ['testgroup', 'test_str']},
+            {'value': 'amqp://guest:guest@127.0.0.1:5672//', 'source': 'ENV:TEST_STUFF_TESTGROUP__TEST_COMPLEX_RAW_STR', 'path': ['testgroup', 'test_complex_raw_str']},  # noqa: E501
+        ]
     ),
-
 ])
-def test_parse_toml(monkeypatch, implicit_depth, environ, expected):
+def test_parse_json(monkeypatch, environ, expected_kw):
     """Check that we can parse toml from environment variables."""
     monkeypatch.setattr(os, 'environ', environ)
-    env_parser = EnvParser(prefix='TEST_STUFF', implicit_depth=implicit_depth)
-    result = env_parser.parse()
-    assert result == expected
+    env_parser = EnvParser(prefix='TEST_STUFF')
+    expected = [Fragment(**kw) for kw in expected_kw]
+    result = list(env_parser.iter_load())
+    if sys.version_info[:2] >= (3, 6):
+        assert result == expected
+    else:
+        # python 3.5 doesn't order dicts so we can't test the exact order
+        def to_set(fragments):
+            return set(str(f) for f in fragments)
+        assert to_set(result) == to_set(expected)

--- a/tests/test_env_parser.py
+++ b/tests/test_env_parser.py
@@ -42,8 +42,9 @@ def test_parse_environment_vars(mock_os_environ, prefix, implicit_depth, split_c
         prefix=prefix,
         split_char=split_char,
         implicit_depth=implicit_depth)
-    result = env_parser.parse()
-    assert result == expected
+    results = [f.expand_value_with_path() for f in env_parser.iter_load()]
+    import pdb; pdb.set_trace()  # noqa: E702
+    assert results == expected
 
 
 @pytest.mark.parametrize('implicit_depth, environ, expected', [

--- a/tests/test_file_loaders.py
+++ b/tests/test_file_loaders.py
@@ -1,0 +1,1 @@
+"""Test file loaders."""

--- a/tests/test_fragment.py
+++ b/tests/test_fragment.py
@@ -1,0 +1,147 @@
+"""Tests for fragments."""
+
+import pytest
+
+from climatecontrol.fragment import Fragment, FragmentPath, EMPTY, FragmentKind
+
+
+def test_fragment_path():
+    """Test fragment path construction."""
+    assert not FragmentPath()  # empty path is falsy
+    assert FragmentPath([]) == FragmentPath(), 'empty fragment paths should be equal'
+    assert FragmentPath(['a', 'stuff', 1]) == FragmentPath(['a', 'stuff', 1]), 'Unexpected equality result'
+    assert FragmentPath(['a', 'stuff', 1]) != FragmentPath(['a', 'wrong', 1]), 'Unexpected inequality result'
+    assert list(FragmentPath(['a', 'stuff', 1])) == ['a', 'stuff', 1], 'Unexpected list conversion result'
+    assert str(FragmentPath(['a', 'stuff', 1])) == "FragmentPath(['a', 'stuff', 1])", 'Unexpected string representation'
+    assert FragmentPath(['a', 'stuff', 1])[1] == 'stuff', 'unexpected indexing'
+
+
+def test_fragment_path_expand():
+    """Test expansion of fragment path."""
+    assert FragmentPath(['a']).expand('test') == {'a': 'test'}
+    assert (
+        FragmentPath(['a', 'stuff', 1, 'bla']).expand() ==
+        {
+            'a': {
+                'stuff': [
+                    EMPTY,
+                    {'bla': EMPTY}
+                ]
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize('a,b,expected', [
+    (['a'], ['b'], []),
+    ([], [], []),
+    ([1, 2, 3], [1, 2, 4, 5], [1, 2]),
+    (['a', 'b', 'c'], ['a', 'b'], ['a', 'b']),
+    (['a', 'b', 'c'], ['a', 'b', 'd'], ['a', 'b']),
+    (['a', 'b', 'c'], ['wrong', 'b', 'c'], []),
+])
+def test_fragment_path_common(a, b, expected):
+    """Test common path."""
+    assert FragmentPath(a).common(b) == FragmentPath(expected)
+
+
+def test_fragment():
+    """Test fragment constructor and representation."""
+    fragment = Fragment(value='bla', source='test', path=['a', 'b'], kind=FragmentKind.REMOVE)
+    assert fragment
+    assert str(fragment) == \
+        "Fragment(value='bla', source='test', path=FragmentPath(['a', 'b']), kind=<FragmentKind.REMOVE: 'REMOVE'>)", \
+        'unexpected string representation'
+
+
+def test_fragment_equality():
+    """Test fragment equality."""
+    assert (
+        Fragment(value='bla', source='test', path=['a', 'b'], kind=FragmentKind.REMOVE) ==
+        Fragment(value='bla', source='test', path=['a', 'b'], kind=FragmentKind.REMOVE)
+    )
+    assert Fragment(value='bla') == Fragment(value='bla')
+    assert Fragment(value='bla') != Fragment(value='blub')
+    assert Fragment(value='bla', source='a') != Fragment(value='bla', source='b')
+    assert Fragment(value='bla', path=['a']) != Fragment(value='bla', path=['b'])
+    assert Fragment(value='bla', kind=FragmentKind.MERGE) != Fragment(value='bla', kind=FragmentKind.REMOVE)
+
+
+def test_fragment_clone():
+    """Test the fragments clone method."""
+    fragment = Fragment('bla')
+    assert fragment.clone() == fragment
+    assert fragment.clone() is not fragment
+    cloned = fragment.clone(source=['a'])
+    assert cloned != fragment
+    assert cloned == Fragment('bla', source=['a'])
+
+
+def test_fragment_iter_leaves():
+    """Test that iterating over fragment leaves gives expected result."""
+    fragment = Fragment('bla')
+    assert list(Fragment('bla').iter_leaves()) == [fragment]
+    actual = list(Fragment({
+        'a': 4,
+        'b': 'test',
+        'c': {
+            'd': [
+                2,
+                {
+                    'e': None,
+                    'f': 'test2'
+                }
+            ]
+        }
+    }).iter_leaves())
+
+    expected = [
+        Fragment(value=4, path=['a']),
+        Fragment(value='test', path=['b']),
+        Fragment(value=2, path=['c', 'd', 0]),
+        Fragment(value=None, path=['c', 'd', 1, 'e']),
+        Fragment(value='test2', path=['c', 'd', 1, 'f'])
+    ]
+
+    assert actual == expected
+
+
+def test_expand_value_with_path():
+    """Test expanding fragment value with path."""
+    actual = Fragment('bla', path=['a', 'b']).expand_value_with_path()
+    expected = {'a': {'b': 'bla'}}
+    assert actual == expected
+
+
+@pytest.mark.parametrize('a_kw, b_kw, expected_kw', [
+    (
+        {'value': 4, 'path': ['a']},
+        {'value': {'a': 5}},
+        {'value': 5, 'path': ['a']}
+    ),
+    (
+        {'value': {'a': 4, 'b': ['c', 'd', 'e']}, 'path': ['root']},
+        {'value': {'bla': 2}, 'path': ['root', 'a', 'b', 1]},
+        {'value': {'a': 4, 'b': ['c', {'bla': 2}, 'e']}, 'path': ['root']}
+    ),
+    (
+        {'value': {'a': 4, 'b': {'c': 'd'}}, 'path': ['root']},
+        {'value': {'b': 2}, 'path': ['root', 'a']},
+        {'value': {'a': 4, 'b': 2}, 'path': ['root']}
+    ),
+    (
+        {'value': 3},
+        {'value': 5},
+        {'value': 5}
+    ),
+    (
+        {'value': {'a': {'b': {'this': 'that'}, 'c': 'test'}, 'bla': 4}},
+        {'value': {'b': 5}, 'kind': FragmentKind.REMOVE, 'path': ['a']},
+        {'value': {'a': {'c': 'test'}, 'bla': 4}},
+    )
+])
+def test_fragment_apply(a_kw, b_kw, expected_kw):
+    """Test the apply method of the fragment class."""
+    actual = Fragment(**a_kw).apply(Fragment(value=b_kw))
+    expected = Fragment(**expected_kw)
+    assert actual == expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -150,6 +150,16 @@ def test_settings_multiple_files(mock_empty_os_environ, mock_settings_files, tmp
     assert dict(settings_map) == mock_settings_files[1]
 
 
+def test_settings_multiple_files_with_glob(mock_empty_os_environ, mock_settings_files, tmpdir, file_extension):
+    """Check that setting multiple files as "settings_files" option works correctly."""
+    directory, _ = os.path.split(mock_settings_files[0][0])
+    glob_path = directory + os.path.sep + '*' + file_extension
+    settings_map = settings_parser.Settings(prefix='TEST_STUFF',
+                                            settings_files=glob_path)
+    assert isinstance(settings_map, Mapping)
+    assert dict(settings_map) == mock_settings_files[1]
+
+
 def test_settings_env_file_and_env(mock_env_settings_file, tmpdir):
     """Check that a settings file from an env variable works together with other env variables settings.
 


### PR DESCRIPTION
### Added

- Allow "_from_env" postfix in variables and load settings from the specified
  environment variable (similar to "from_file").
- Add "update_log" property which specifies a log of all variables loaded or
  removed/replaced.
- Allow overwriting / merging lists

### Changed

- Use fragments as base data structure for building settings map
- Add python 3.7 and 3.8 to CI and update development environment config to 3.8

Closes #7 
