### PR TITLE
Use passed click_obj on type for async support

### DIFF
--- a/climatecontrol/cli_utils.py
+++ b/climatecontrol/cli_utils.py
@@ -48,7 +48,7 @@ def click_settings_file_option(
     option_kwargs = dict(
         help="Settings file path for loading settings from file.",
         callback=validate,
-        type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+        type=click_obj.Path(exists=True, dir_okay=False, resolve_path=True),
         expose_value=False,
         is_eager=True,
         multiple=True,


### PR DESCRIPTION
Current implementation produces an error when using asyncclick
`AttributeError: 'Path' object has no attribute '__name__'`

Monkey patching fixes the bug but would be better to be natively supported. Follows the same pattern used by you below when defining the option